### PR TITLE
Improve documentation and fix pytest test class detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,13 @@ Key modules:
 
 - `main.py`: CLI entrypoint, feedback persistence, session logging
 - `workflow.py`: LangGraph workflow graph (stages + dynamic delegation)
-- `agents/`: agent implementations and provider/model factory
+- `agents/`: agent implementations (`base.py`, `dlpfc.py`, `specialized.py`) and the provider/model `factory.py`
+- `utils/config.py`: YAML config loader with legacy env-var fallback
 - `config/agents.yaml`: per-agent model/provider configuration
-- `feedback_history.json`: persistent Human-in-the-Loop (HITL) feedback
-- `logs/`: per-run session logs
+- `docs/local_models.md`: guide for Ollama / HuggingFace / OpenAI configuration
+- `tests/`: pytest suite covering agents, workflow, HITL, and CLI
+- `feedback_history.json`: persistent Human-in-the-Loop (HITL) feedback (gitignored)
+- `logs/`: per-run session logs (gitignored)
 
 ## **License**
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -8,6 +8,8 @@ from openai import AuthenticationError
 
 class TestAgent(BaseAgent):
     """Test implementation of BaseAgent"""
+    __test__ = False  # Not a pytest test class; opts out of test collection.
+
     def __init__(self):
         super().__init__(agent_name="TEST", model_env_key="TEST_MODEL")
         


### PR DESCRIPTION
## Summary
This PR improves project documentation clarity and fixes a pytest configuration issue in the test suite.

## Key Changes
- **Documentation improvements in README.md:**
  - Clarified `agents/` module structure with specific file names (`base.py`, `dlpfc.py`, `specialized.py`, `factory.py`)
  - Added `utils/config.py` to the key modules list with description of YAML config loading with env-var fallback
  - Added `docs/local_models.md` guide reference for model provider configuration
  - Added `tests/` pytest suite to key modules
  - Clarified that `feedback_history.json` and `logs/` are gitignored

- **Test suite fix in `tests/test_base_agent.py`:**
  - Added `__test__ = False` class attribute to `TestAgent` to prevent pytest from attempting to collect it as a test class
  - This is a non-test helper class used for testing the `BaseAgent` base class, so it should be excluded from test discovery

## Implementation Details
The `TestAgent` class is a concrete implementation of the abstract `BaseAgent` used for unit testing purposes, not a test case itself. Setting `__test__ = False` follows pytest conventions for marking classes that should not be collected as tests, preventing potential collection warnings or errors.

https://claude.ai/code/session_01FvPTenCSHQnXWmUiWzPCJo