### PR TITLE
Bump version to 1.3.0 and document new configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 1.3.0 — 2026-07-30
+
+Full audit and repair of the multi-agent pipeline (PR #15). Verified by 217
+offline tests, ruff and mypy in CI (Python 3.11–3.13), and a live end-to-end
+validation against real Ollama models (all checks passing, including
+schema-honored delegation and token capture).
+
+### Routing — the multi-agent system is now actually multi-agent
+- DLPFC's delegation decision was destroyed by a response reformatter before
+  the router read it; nearly every run silently collapsed to MPFC-only. The
+  decision is now requested as a schema-validated object
+  (`with_structured_output`) with the text parser as fallback, and every run
+  records `delegation_source` in its session log.
+- Removed an OFC keyword collision that selected reward processing whenever
+  MPFC's own role was described; keyword matching is word-boundary anchored.
+
+### Honest failure reporting
+- Runs with failed specialists were logged `completed: true` with no trace of
+  the failures, and the failed agents' error strings were fed to MPFC as peer
+  "insights". Failed agents are now excluded from synthesis, MPFC is told
+  which perspectives are missing, the CLI reports partial results, and the
+  session log carries `degraded` and `agent_errors`.
+
+### Resource bounds
+- HITL feedback history was unbounded and injected into every prompt of every
+  run; ~25 entries filled an 8k context window, then every agent failed at
+  once. Now recency-windowed and character-budgeted (configurable via
+  `SCANUE_FEEDBACK_*`).
+- `num_ctx` / `max_tokens` configurable per model; Ollama's silent prompt
+  truncation is now detectable; `logs/` pruned to the most recent 50; state
+  paths anchored to the project root (`SCANUE_STATE_DIR` overrides).
+
+### Resilience
+- Retries with exponential backoff for all providers (previously OpenAI-only,
+  leaving the default all-Ollama config with none).
+- Per-model `timeout:` in config is honoured (a hardcoded 30 s previously won).
+
+### Observability
+- Per-stage token usage, finish reason, model/provider attribution and prompt
+  capture; run-level totals and wall clock; truncated generations flagged.
+- `scripts/validate.py`: one-command validation against a real provider.
+
+### Quality
+- Substantive prompts for all four specialists; MPFC explicitly synthesizes,
+  attributes and reconciles peer analyses; `agents/specialized.py` generated
+  from a single table.
+- Packaging via `pyproject.toml` (`pip install -e .`, `scanue` console
+  script); `requirements.txt` removed; ruff + mypy blocking in CI; accurate
+  state typing; EOF/empty-input CLI fixes; JSON log corruption on
+  unserializable values fixed; DOI badge corrected to this repository's own
+  Zenodo record (10.5281/zenodo.14510406).
+
+## 1.2.0-beta and earlier
+
+See git history and the release notes on GitHub.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Key modules:
 - `utils/config.py`: YAML config loader with legacy env-var fallback
 - `config/agents.yaml`: per-agent model/provider configuration
 - `docs/local_models.md`: guide for Ollama / HuggingFace / OpenAI configuration
+- `CHANGELOG.md`: notable changes per release
 - `tests/`: pytest suite covering agents, workflow, HITL, and CLI
 - `scripts/validate.py`: one-command validation against a real provider
 - `feedback_history.json`: persistent Human-in-the-Loop (HITL) feedback (gitignored)

--- a/docs/local_models.md
+++ b/docs/local_models.md
@@ -20,12 +20,40 @@ agents:
         name: "llama3:70b"       # model identifier
         temperature: 0.1         # creativity level (0.0 - 1.0)
         base_url: "http://localhost:11434" # optional for local
-      
+        timeout: 120             # seconds for one LLM call (default: 30)
+        max_retries: 3           # retries after the first attempt (0 disables)
+        num_ctx: 8192            # ollama only: context window in tokens
+        max_tokens: 1024         # cap on output length (ollama: num_predict)
+
       # Optional specialized models (future proofing)
       fast:
         provider: "ollama"
         name: "llama3:8b"
         temperature: 0.0
+```
+
+### Options that matter most for local models
+
+- **`num_ctx` — set it explicitly.** Left unset, the Ollama server applies its
+  own default (commonly 2048 tokens) and **silently drops** anything past it —
+  no error, no log line, just a truncated prompt. Match it to your model's real
+  capability. SCANUE logs each prompt's approximate token count (visible with
+  `SCANUE_LOG_LEVEL=DEBUG`) so you can see how close you are.
+- **`timeout`** — local models on CPU can be slow; the default 30 s per call is
+  tuned for cloud APIs. 120 s is a sensible floor for CPU inference.
+- **`max_retries`** — retries with exponential backoff apply to every provider,
+  so a transient blip on a local server no longer fails the whole stage.
+- **`max_tokens`** — if a response hits this cap, the run summary flags the
+  stage (`finish_reason: length`) instead of passing a cut-off answer as
+  complete.
+
+### Verifying your setup
+
+After configuring, run one real task with pass/fail checks — schema compliance,
+token capture, context headroom:
+
+```bash
+python scripts/validate.py
 ```
 
 ## Supported Providers
@@ -75,6 +103,16 @@ Each agent mimics a specific cognitive function. Here are recommended model type
 | **OFC** | Reward Processing | Analytical, math-capable models |
 | **ACC** | Conflict Monitoring | Strict, logical models with low temperature |
 | **MPFC** | Integration | High context window models to synthesize all inputs |
+
+## Small models and delegation
+
+DLPFC decides which specialists run, and it is asked for a **schema-validated**
+decision (`with_structured_output`). Small local models sometimes cannot honor
+the schema, in which case SCANUE falls back to parsing the text reply and
+records how the decision was made in `logs/session_*.json` as
+`delegation_source`. If your runs show anything other than `structured_output`
+there, routing is being inferred rather than stated — a larger DLPFC model
+usually fixes it. See the README's Delegation section for the full table.
 
 ## Backward Compatibility
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scanue-v22"
-version = "1.2.0"
+version = "1.3.0"
 description = "Brain-inspired multi-agent CLI orchestrating specialized PFC-region agents with LangGraph"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Follow-up to #15 (already merged). Two commits that were pushed to the branch after that PR merged, so they were never included — rebased onto current `main` and opened as a fresh PR per the standard "already merged" workflow.

- **Version bump to 1.3.0** — reflects the scope of #15 (routing correctness, resilience, observability, resource limits, prompt rewrites) more accurately than a patch bump on 1.2.0.
- **Documentation**: `docs/local_models.md` was the stale doc — it documented none of the new per-model options (`timeout`, `max_retries`, `num_ctx`, `max_tokens`) added in #15, including `num_ctx`, which matters most for local models since Ollama silently drops any prompt past its context window with no error. Also adds `CHANGELOG.md` and a pointer to `scripts/validate.py`.

Cross-checked every documented claim against the code before pushing: all `SCANUE_*` env vars read at runtime are documented, all per-model config keys the factory honours are documented, and every file path referenced in the docs exists.

## Test plan
- [x] `pytest tests/` — 217 passed
- [x] `ruff check .` — clean
- [x] `mypy main.py workflow.py agents utils scripts` — clean
- [x] Diff against `main` is exactly the intended 4 files (`pyproject.toml`, `README.md`, `docs/local_models.md`, `CHANGELOG.md`)

https://claude.ai/code/session_01XgvCJqUHZKuGMJc7z9kZGQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01XgvCJqUHZKuGMJc7z9kZGQ)_